### PR TITLE
Add `guardian/etag-caching` to list of projects maintained

### DIFF
--- a/code-maintained-by-the-guild.md
+++ b/code-maintained-by-the-guild.md
@@ -16,6 +16,12 @@ Guardian Scala repos ✨
 
 **Used by:** [Many](https://github.com/search?q=org%3Aguardian+%22guardian%2Fsetup-scala%22++NOT+is%3Aarchived+language%3AYAML&type=code&l=YAML) Guardian Scala projects, eg [play-googleauth](https://github.com/guardian/play-googleauth/pull/264), [mobile-n10n](https://github.com/guardian/mobile-n10n/pull/1325)
 
+### [etag-caching](https://github.com/guardian/etag-caching)
+[![aws-s3-sdk-v2 Scala version support](https://index.scala-lang.org/guardian/etag-caching/aws-s3-sdk-v2/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/etag-caching/aws-s3-sdk-v2)
+
+**Used by:** [frontend](https://github.com/guardian/frontend/pull/26338), [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/287)
+
+
 ### [play-googleauth](https://github.com/guardian/play-googleauth)
 [![play-googleauth artifacts](https://index.scala-lang.org/guardian/play-googleauth/play-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-googleauth/play-v30/)
 


### PR DESCRIPTION
[`guardian/etag-caching`](https://github.com/guardian/etag-caching) is a Scala library that can help reduce CPU & Network consumption for any service that polls S3 or HTTP resources. It also provides abstractions that can allow API-independence from AWS SDK version (ie S3-use not directly tied to AWS SDK v1 or v2).

It's already used by these projects:

* Frontend: https://github.com/guardian/frontend/pull/26338
* facia-scala-client: https://github.com/guardian/facia-scala-client/pull/287

Doing a quick search for S3-polling code at the Guardian, I can see there are plenty of other places where it could be used:

* [typerighter `MatcherProvisionerService`](https://github.com/guardian/typerighter/blob/b6f8a3daa959ee1a9478e7260ba8badf8797eb9c/apps/checker/app/services/MatcherProvisionerService.scala#L72-L83)
* [mobile-n10n `S3DataStore`](https://github.com/guardian/mobile-n10n/blob/75cfbfff1ec52a332f1d04a63680f126fcbd6cf1/notification/app/notification/NotificationApplicationLoader.scala#L75-L77)
* [pan-domain-authentication `Settings.Refresher`](https://github.com/guardian/pan-domain-authentication/blob/1db3864e00aae3258f8506c95a713e9e52487e61/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala#L35-L36)
* [permissions `S3PermissionsProvider`](https://github.com/guardian/permissions/blob/b1a91466838024be7d0230a9d5a846ef7b83361a/client/src/main/scala/com/gu/permissions/PermissionsProvider.scala#L140-L150)

### After merging

If merged, we need to add the @guardian/scala-guild GitHub team to the [`guardian/etag-caching`](https://github.com/guardian/etag-caching) repo as:

- [ ] a team with `Admin` permissions
- [ ] `.github/CODEOWNERS` (eg as in https://github.com/guardian/redirect-resolver/pull/22)
