### PR TITLE
Add `guardian/play-json-extensions` to the list of maintained projects

### DIFF
--- a/code-maintained-by-the-guild.md
+++ b/code-maintained-by-the-guild.md
@@ -34,6 +34,12 @@ Guardian Scala repos ✨
 **Used by:** [ophan](https://github.com/guardian/ophan/pull/2712), [riff-raff](https://github.com/guardian/riff-raff/pull/491)
 
 
+### [play-json-extensions](https://github.com/guardian/play-json-extensions)
+[![play-json-extensions Scala version support](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/play-json-extensions/play-json-extensions)
+
+**Used by:** [mobile-apps-api](https://github.com/guardian/mobile-apps-api/pull/3341), [media-atom-maker](https://github.com/guardian/media-atom-maker/pull/1206)
+
+
 ### [redirect-resolver](https://github.com/guardian/redirect-resolver)
 [![redirect-resolver Scala version support](https://index.scala-lang.org/guardian/redirect-resolver/redirect-resolver/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/redirect-resolver/redirect-resolver)
 


### PR DESCRIPTION
[`guardian/play-json-extensions`](https://github.com/guardian/play-json-extensions) is a minimal fork of the unmaintained [`bizzabo/play-json-extension`](https://github.com/bizzabo/play-json-extensions) library, that adds support for Scala 2.13.12 and above:

* https://github.com/scala/bug/issues/12862

`guardian/play-json-extensions` needs an owner for the purposes of security updates, and I believe that it meets [the criteria](https://github.com/guardian/scala-guild-administration?tab=readme-ov-file#criteria-for-code-being-maintained-by-the-guild) for being maintained by the Guardian's Scala Guild. In particular:

> * Be consumed by **more than one Product team** at the Guardian - if only one Product team consumes a library, then by default, they should maintain it

Our fork is actively used by:

* `mobile-apps-api`: https://github.com/guardian/mobile-apps-api/pull/3341
* `media-atom-maker`: https://github.com/guardian/media-atom-maker/pull/1206

The original legacy unmaintained project ([`bizzabo/play-json-extension`](https://github.com/bizzabo/play-json-extension), Maven group-id `ai.x`) is also used by several projects at the Guardian:

https://github.com/search?q=org%3Aguardian+%22play-json-extensions%22++NOT+is%3Aarchived&type=code

...those projects should probably switch to our Guardian fork, in order to get support for Scala 2.13.12 and above, and of course any security patches we push out.
